### PR TITLE
shek8034: Added localStorage getSize Functionality

### DIFF
--- a/app/scripts/ng-xdLocalStorage.js
+++ b/app/scripts/ng-xdLocalStorage.js
@@ -57,7 +57,7 @@ angular.module('xdLocalStorage', [])
         return action('removeItem', key);
       },
       key: function (index) {
-        return action('key', index)
+        return action('key', index);
       },
       clear: function () {
         return action('clear');

--- a/app/scripts/xdLocalStorage.js
+++ b/app/scripts/xdLocalStorage.js
@@ -123,6 +123,12 @@ window.xdLocalStorage = window.xdLocalStorage || (function () {
       }
       buildMessage('key', index,  null, callback);
     },
+    getSize: function(callback) {
+      if(!isApiReady()) {
+        return;
+      }
+      buildMessage('size', null, null, callback);
+    },
     clear: function (callback) {
       if (!isApiReady()) {
         return;

--- a/app/scripts/xdLocalStoragePostMessageApi.js
+++ b/app/scripts/xdLocalStoragePostMessageApi.js
@@ -45,6 +45,11 @@
     postData(id, {key: key});
   }
 
+  function getSize(id) {
+    var size = JSON.stringify(localStorage).length;
+    postData(id, {size: size});
+  }
+
   function clear(id) {
     localStorage.clear();
     postData(id, {});
@@ -66,6 +71,8 @@
         removeData(data.id, data.key);
       } else if (data.action === 'key') {
         getKey(data.id, data.key);
+      } else if (data.action === 'size') {
+        getSize(data.id);
       } else if (data.action === 'clear') {
         clear(data.id);
       }

--- a/test/specs/xdLocalStorage.js
+++ b/test/specs/xdLocalStorage.js
@@ -75,4 +75,13 @@ describe('xdLocalStorage test', function () {
       });
     });
   });
+
+  it('should return the size of local storage', function (done) {
+    xdLocalStorage.setItem('itemKey', 'value', function () {
+        xdLocalStorage.getSize(function (res) {
+            expect(res.size).toBe(5);
+            done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
There is no way to get the size of localStorage, to check how much localStorage is consumed.
Added getSize() functionality to get the size of locaStorage, which returns the size in bytes.